### PR TITLE
V1.1.0 updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+# CI workflow for siebenuhr_esphome
+# Verifies ESPHome configuration compiles successfully
+
+name: Build
+
+on:
+  push:
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  build-esphome:
+    name: ESPHome Build Check
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Checkout siebenuhr_core library
+        uses: actions/checkout@v4
+        with:
+          repository: soliddifference/siebenuhr_core
+          ref: main
+          path: tmp/siebenuhr_core
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+      
+      - name: Cache ESPHome build
+        uses: actions/cache@v4
+        with:
+          path: |
+            .esphome
+            ~/.platformio
+          key: esphome-${{ runner.os }}-${{ hashFiles('siebenuhr_local.yaml') }}
+          restore-keys: |
+            esphome-${{ runner.os }}-
+      
+      - name: Install dependencies
+        run: uv sync
+      
+      - name: Create secrets.yaml for CI
+        run: |
+          cat > secrets.yaml << 'EOF'
+          wifi_ssid: "test-network"
+          wifi_password: "test-password"
+          apiKey: "dGVzdC1hcGkta2V5LWZvci1jaS1idWlsZA=="
+          otaPassword: "test-ota-password"
+          EOF
+      
+      - name: Compile ESPHome configuration
+        run: uv run esphome compile siebenuhr_local.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           cat > secrets.yaml << 'EOF'
           wifi_ssid: "test-network"
           wifi_password: "test-password"
-          apiKey: "dGVzdC1hcGkta2V5LWZvci1jaS1idWlsZA=="
+          apiKey: "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="
           otaPassword: "test-ota-password"
           EOF
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,11 @@ jobs:
       
       - name: Create secrets.yaml for CI
         run: |
-          cat > secrets.yaml << 'EOF'
+          API_KEY=$(openssl rand -base64 32)
+          cat > secrets.yaml << EOF
           wifi_ssid: "test-network"
           wifi_password: "test-password"
-          apiKey: "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="
+          apiKey: "${API_KEY}"
           otaPassword: "test-ota-password"
           EOF
       

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ secrets.yaml
 .vscode
 *.pyc
 __pycache__/
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Siebenuhr ESPHome
 
+[![Build](https://github.com/soliddifference/siebenuhr_esphome/actions/workflows/build.yml/badge.svg)](https://github.com/soliddifference/siebenuhr_esphome/actions/workflows/build.yml)
+
 ESPHome (for Home Assistant) integration with **Siebenuhr 7-segment LED clocks**. This component wraps the [siebenuhr_core](https://github.com/soliddifference/siebenuhr_core) library as an [ESPHome External Component](https://esphome.io/components/external_components.html), enabling Home Assistant integration with OTA updates, WiFi config, and light controls.
 
 The hardwareclocks can be ordered from our web shop at [soliddifference.com](https://soliddifference.com/)

--- a/README.md
+++ b/README.md
@@ -1,83 +1,83 @@
 # Siebenuhr ESPHome
 
-This repository develops siebenuhr_esphome, an ESPHome-compatible version of the Siebenuhr ESP32 firmware. It transitions the standalone PlatformIO-based firmware into n [ESPHome External Component](https://esphome.io/components/external_components.html).
+ESPHome (for Home Assistant) integration with **Siebenuhr 7-segment LED clocks**. This component wraps the [siebenuhr_core](https://github.com/soliddifference/siebenuhr_core) library as an [ESPHome External Component](https://esphome.io/components/external_components.html), enabling Home Assistant integration with OTA updates, WiFi config, and light controls.
+
+The hardwareclocks can be ordered from our web shop at [soliddifference.com](https://soliddifference.com/)
+
+> If you don't use Home Assistant, you can use our [standalone "factory" firmware](https://github.com/soliddifference/siebenuhr) which can be flashed using PlatformIO.
 
 ---
 
 ## Prerequisites
 
-Before proceeding, ensure you have the following installed:
-
-1. [ESPHome](https://esphome.io/guides/installing.html) installed locally or in a Home Assistant environment.
-2. An ESP32 board and the necessary USB connection for flashing.
-3. A configured development environment (Python, ESPHome CLI, VisualCode, etc.).
+- [ESPHome](https://esphome.io/guides/installing.html) installed locally or via Home Assistant
+- ESP32 board with USB connection for flashing
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) for Python dependency management
 
 ---
 
 ## Getting Started
 
-### Prerequisites
+1. Clone the repository:
 
-1. Ensure you have [ESPHome](https://esphome.io/) installed and set up on your system.
-2. Clone the repository to your local machine:
    ```bash
    git clone https://github.com/soliddifference/siebenuhr_esphome
    cd siebenuhr_esphome
    ```
-3. Install uv: https://docs.astral.sh/uv/getting-started/installation/
-4. Run `uv sync`
-5. Activate the Python virtual environment
 
-```bash
-# macOS and Linux
-source .venv/bin/activate
+2. Install dependencies and activate the virtual environment:
 
-# Windows
-.venv\Scripts\activate
-```
+If needed, install uv: <https://docs.astral.sh/uv/getting-started/installation/> and then:
+
+   ```bash
+   uv sync
+   source .venv/bin/activate  # macOS/Linux
+   # or: .venv\Scripts\activate  # Windows
+   ```
 
 ### Configuration
 
-1. Make a copy of either `siebenuhr_git.yaml` or `siebenuhr_local.yaml`:
-
-   - Use `siebenuhr_local.yaml` for development purposes as it refers to the local version of the code and is optimized for fast compile and testing iterations.
+1. **Create your secrets file:**
 
    ```bash
-   cp siebenuhr_local.yaml your_modified_config.yaml
+   cp secrets_template.yaml secrets.yaml
    ```
 
-2. Edit `your_modified_config.yaml` to configure it for your local environment:
+   Edit `secrets.yaml` and enter your WiFi credentials and API keys.
 
-   - Update the most critical settings, specifically WiFi credentials, in the `wifi` section:
-     ```yaml
-     wifi:
-       ssid: !secret wifi_ssid
-       password: !secret wifi_password
-     ```
+2. **Choose a configuration:**
 
-3. **Switching to a Local Repository for Development:**
+   - `siebenuhr_git.yaml` — Uses GitHub for both the component and core library.
+   - `siebenuhr_local.yaml` — Uses local paths if changes are needed to the siebenuhr_core library.
 
-   - To work with a local version of the library during development, reference the library using a `file://` path instead of a GitHub URL. This allows for faster compile and testing without requiring Git commits.
+3. **Local development with siebenuhr_core:**
 
-     ```yaml
-     libraries:
-       - file://C:\local\path\to\the\core_package\dir\siebenuhr_core
-     ```
-
-   - Replace the path above with the location of your locally checked-out repository.
-
-### Compiling and Testing
-
-1. Test if your setup compiles by running:
+   Clone the core library into the `tmp/` folder:
 
    ```bash
-   esphome compile your_modified_config.yaml
+   git clone https://github.com/soliddifference/siebenuhr_core.git tmp/siebenuhr_core
    ```
 
-2. Alternatively, you can compile, upload, and connect to your device in one step:
-   ```bash
-   esphome run your_modified_config.yaml
+   The `siebenuhr_local.yaml` references it using a portable path:
+
+   ```yaml
+   libraries:
+     - file://${sysenv.PWD}/tmp/siebenuhr_core
    ```
+
+   This allows editing the core library locally without Git commits for each test.
+
+### Compiling and Flashing
+
+Compile and upload to your device:
+
+```bash
+esphome run siebenuhr_local.yaml   # for local development
+esphome run siebenuhr_git.yaml     # for production/release
+esphome logs siebenuhr_local.yaml   # view device logs (wifi or usb connection)
+```
+
+This will also show you the logs from the device in the terminal.
 
 ---
 

--- a/components/siebenuhr/light.py
+++ b/components/siebenuhr/light.py
@@ -10,7 +10,7 @@ CONF_PERSONALITY = "personality"
 CONF_POWER_MONITORING = "power_monitoring"
 
 empty_light_ns = cg.esphome_ns.namespace("siebenuhr")
-EmptyLightOutput = empty_light_ns.class_("SiebenuhrClock", light.LightOutput)
+EmptyLightOutput = empty_light_ns.class_("SiebenuhrClock", light.LightOutput, cg.Component)
 
 CONFIG_SCHEMA = light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(
     {
@@ -25,6 +25,7 @@ CONFIG_SCHEMA = light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_OUTPUT_ID])
+    await cg.register_component(var, config)
     await light.register_light(var, config)
 
     if CONF_TIME_ID in config:
@@ -45,5 +46,3 @@ async def to_code(config):
         "MINI": 1,
     }
     cg.add(var.set_type(type_map[config[CONF_TYPE]]))
-
-    cg.add(var.setup())

--- a/secrets_template.yaml
+++ b/secrets_template.yaml
@@ -1,12 +1,20 @@
-# make a copy of this file and rename it to secrets.yaml
-# and fill in the values
+# Siebenuhr ESPHome Secrets
+# 
+# Copy this file to secrets.yaml and fill in the values:
+#   cp secrets_template.yaml secrets.yaml
+#
+# NOTE: Key names changed in v1.1.0:
+#   - wifiSSID → wifi_ssid
+#   - wifiPassword → wifi_password
+#
+# If upgrading from an older version, update your secrets.yaml accordingly.
 
-# Your Wi-Fi SSID and password
+# Your Wi-Fi credentials
 wifi_ssid: ""
 wifi_password: ""
 
-# ESPHome API Encryption Key
+# ESPHome API encryption key (generate with: esphome generate-key)
 apiKey: ""
 
-# OTA PAssword ESPHome
+# OTA update password
 otaPassword: ""

--- a/siebenuhr_git.yaml
+++ b/siebenuhr_git.yaml
@@ -1,7 +1,11 @@
 esphome:
-  name: "siebenuhr"
-  friendly_name: SiebenUhr::Mini
-
+  name: siebenuhr
+  friendly_name: Siebenuhr
+  platformio_options:
+    build_flags:
+      - -D FASTLED_DITHER_ENABLED=0
+      - -D SENSOR_READ_INTERVAL_MS=5000
+      # - -D DOUBLE_CLICK_PERSONALITY_ENABLED
   libraries:
     - Fastled
     - RunningAverage
@@ -27,7 +31,7 @@ external_components:
     refresh: 0s
 
 logger:
-  # level: ERROR
+  level: INFO
 
 api:
   encryption:
@@ -38,8 +42,12 @@ ota:
     password: !secret otaPassword
 
 wifi:
-  ssid: !secret wifiSSID
-  password: !secret wifiPassword
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  reboot_timeout: 0s # disables reboot on failed Wi-Fi
+  # fast_connect: on # Uncomment if you want to use fast connect, required for hidden SSID
+
+captive_portal:
 
 time:
   - platform: sntp
@@ -50,13 +58,16 @@ light:
     id: my_siebenuhr
     name: Siebenuhr
     restore_mode: RESTORE_DEFAULT_ON 
-    type: MINI
+    type: MINI # 28 LEDs per digit
+    # type: REGULAR # 119 LEDs per digit (the big clock)
     personality: SOLIDCOLOR
+    # personality: COLORWHEEL
+    # personality: RAINBOW
+    # personality: MOSAIK
     # auto_brightness: True
     power_monitoring: True
     time_id: sntp_time
     default_transition_length: 0s
-
 
 text:
   - platform: template
@@ -65,9 +76,6 @@ text:
     name: "Siebenuhr Text Input"
     set_action:
       then:
-        # - logger.log:
-        #     format: "Received: %s"
-        #     args: [x.c_str()]
         - lambda: |-
             // esphome::siebenuhr::global_siebenuhr_clock->set_text(x);
             esphome::siebenuhr::global_siebenuhr_clock->set_notification(x, 4000);

--- a/siebenuhr_local.yaml
+++ b/siebenuhr_local.yaml
@@ -1,6 +1,11 @@
 esphome:
   name: siebenuhr
   friendly_name: Siebenuhr
+  platformio_options:
+    build_flags:
+      - -D FASTLED_DITHER_ENABLED=0
+      - -D SENSOR_READ_INTERVAL_MS=5000
+      # - -D DOUBLE_CLICK_PERSONALITY_ENABLED
   libraries:
     - Fastled
     - RunningAverage
@@ -10,7 +15,7 @@ esphome:
     - adafruit/Adafruit BusIO
     - adafruit/Adafruit INA219
     - igorantolic/Ai Esp32 Rotary Encoder
-    - file://<insert_your_path_to_siebenuhr_core_here>
+    - file://${sysenv.PWD}/tmp/siebenuhr_core
 
 
 esp32:
@@ -37,8 +42,8 @@ ota:
     password: !secret otaPassword
 
 wifi:
-  ssid: !secret wifiSSID
-  password: !secret wifiPassword
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
   reboot_timeout: 0s # disables reboot on failed Wi-Fi
   # fast_connect: on # Uncomment if you want to use fast connect, required for hidden SSID
 
@@ -53,7 +58,8 @@ light:
     id: my_siebenuhr
     name: Siebenuhr
     restore_mode: RESTORE_DEFAULT_ON 
-    type: REGULAR # alternate value: MINI
+    type: MINI # 28 LEDs per segment
+    # type: REGULAR # 119 LEDs per segment (the big clock)
     personality: COLORWHEEL
     # personality: SOLIDCOLOR
     # personality: RAINBOW


### PR DESCRIPTION
- Standardize YAML config params (snake_case, match core names)
- fixed Light component init (use `cg.register_component()`)
- add support for build flags (in harmony with standalone firmware and core)
- Add [github action](https://github.com/soliddifference/siebenuhr_esphome/actions) to build esphome using latest core lib and yaml settings

Note: after merge we will need to `git tag v1.1.0 && git push origin v1.1.0` at siebenuhr_core and change the build scripts here to use the latest release